### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://cruzex.visualstudio.com/4eec5229-21d3-485b-a3d0-60081f2e388e/bbc2d752-996b-4c20-8764-0601c08c1c71/_apis/work/boardbadge/9783f573-d24c-4097-846d-8b4e00232fa9)](https://cruzex.visualstudio.com/4eec5229-21d3-485b-a3d0-60081f2e388e/_boards/board/t/bbc2d752-996b-4c20-8764-0601c08c1c71/Microsoft.RequirementCategory)
 # Test
 for my test


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#12](https://cruzex.visualstudio.com/4eec5229-21d3-485b-a3d0-60081f2e388e/_workitems/edit/12). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.

[![Board Status](https://cruzex.visualstudio.com/4eec5229-21d3-485b-a3d0-60081f2e388e/bbc2d752-996b-4c20-8764-0601c08c1c71/_apis/work/boardbadge/9783f573-d24c-4097-846d-8b4e00232fa9)](https://cruzex.visualstudio.com/4eec5229-21d3-485b-a3d0-60081f2e388e/_boards/board/t/bbc2d752-996b-4c20-8764-0601c08c1c71/Microsoft.RequirementCategory/)